### PR TITLE
Don't scroll to bottom when new chat message is logged

### DIFF
--- a/views/application.js.erb
+++ b/views/application.js.erb
@@ -42,7 +42,6 @@ function chat(message) {
 function logChatMessage(payload) {
     var logClass = '.conversation-log';
     $('.conversation-list').append('<li><h4><small>' + payload.message + ' (' + formatDate(payload.date) + ')</small></h4></li>');
-    $(logClass).animate({ scrollTop: $(logClass)[0].scrollHeight }, 1000);
 }
 
 function formatDate(dateStr) {


### PR DESCRIPTION
Make it easier to read scrollback while people are still adding comments